### PR TITLE
Enable -Os back to audioflinger

### DIFF
--- a/services/audioflinger/Android.mk
+++ b/services/audioflinger/Android.mk
@@ -67,6 +67,8 @@ endif
 endif
 #QTI Resampler
 
+LOCAL_CFLAGS += -Os
+
 LOCAL_MODULE:= libaudioflinger
 LOCAL_32_BIT_ONLY := true
 


### PR DESCRIPTION
Using plain -O3 causes compilation error.
Fix this by adding -Os to the CFLAGS.

Signed-off-by: arter97 qkrwngud825@gmail.com
