### PR TITLE
remove the strict overflow errors on building this module

### DIFF
--- a/media/libstagefright/codecs/m4v_h263/dec/Android.mk
+++ b/media/libstagefright/codecs/m4v_h263/dec/Android.mk
@@ -47,6 +47,9 @@ LOCAL_C_INCLUDES := \
 LOCAL_CFLAGS := -DOSCL_EXPORT_REF= -DOSCL_IMPORT_REF=
 
 LOCAL_CFLAGS += -Werror
+ifeq ($(TARGET_ARCH),arm64)
+LOCAL_CFLAGS += -Wno-error=strict-overflow
+endif
 
 include $(BUILD_STATIC_LIBRARY)
 


### PR DESCRIPTION
instead of disabling this error for all builds and to only run this function for  64bit build; created an ifeq which specifies the target arch as being 64 bit and only utilizing this cf-flag for this bit-set and this specific error in the codec.
