### PR TITLE
 Strict overflow revert 

### DIFF
--- a/media/libstagefright/codecs/m4v_h263/dec/Android.mk
+++ b/media/libstagefright/codecs/m4v_h263/dec/Android.mk
@@ -47,9 +47,6 @@ LOCAL_C_INCLUDES := \
 LOCAL_CFLAGS := -DOSCL_EXPORT_REF= -DOSCL_IMPORT_REF=
 
 LOCAL_CFLAGS += -Werror
-ifeq ($(TARGET_ARCH),arm64)
-LOCAL_CFLAGS += -Wno-error=strict-overflow
-endif
 
 include $(BUILD_STATIC_LIBRARY)
 


### PR DESCRIPTION
revert commit 59dde08

commit reverts the earlier commit due to merely masking the error. On warning or disregarding strict overflow the module breaks multiple aspects relating to video and its use throughout the system/device. revert this commit to further work out a better solution
