### PR TITLE
Revert "DO NOT MERGE: Lock drm plugin API calls globally, not per Med…

### DIFF
--- a/media/libmediaplayerservice/Drm.cpp
+++ b/media/libmediaplayerservice/Drm.cpp
@@ -46,7 +46,6 @@ static bool checkPermission(const char* permissionString) {
 KeyedVector<Vector<uint8_t>, String8> Drm::mUUIDToLibraryPathMap;
 KeyedVector<String8, wp<SharedLibrary> > Drm::mLibraryPathToOpenLibraryMap;
 Mutex Drm::mMapLock;
-Mutex Drm::mLock;
 
 static bool operator<(const Vector<uint8_t> &lhs, const Vector<uint8_t> &rhs) {
     if (lhs.size() < rhs.size()) {

--- a/media/libmediaplayerservice/Drm.h
+++ b/media/libmediaplayerservice/Drm.h
@@ -134,7 +134,7 @@ struct Drm : public BnDrm,
     virtual void binderDied(const wp<IBinder> &the_late_who);
 
 private:
-    static Mutex mLock;
+    mutable Mutex mLock;
 
     status_t mInitCheck;
 


### PR DESCRIPTION
…iaDrm instance"

This reverts commit d383176062362947455866af831d7db6ab085361.

Change-Id: I0509f7eadb3a27c4cadbd3088cb57a588463f457
